### PR TITLE
Creates image based on tailscale source code

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,3 +3,10 @@ export SECRETS_DIR=${PROJECT_DIR}/secrets
 export WORK_DIR=${PROJECT_DIR}/work
 
 PATH=${PROJECT_DIR}/bin:${PATH}
+
+export PARAMS_YAML=${PROJECT_DIR}/secrets/params.yml
+watch_file ${PARAMS_YAML}
+
+export VAULT_FQDN=$(yq e .vault.fqdn $PARAMS_YAML)
+export VAULT_ADDR=https://$VAULT_FQDN
+

--- a/bin/setup-harbor
+++ b/bin/setup-harbor
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+REGISTRY=$(yq e .harbor.fqdn ${PARAMS_YAML})
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @${PROJECT_DIR}/harbor/project/network.json
+GITHUB_REGISTRY=$(jq -n --arg githubUser $(yq e .github.user $PARAMS_YAML) --arg githubToken $(yq e .github.token $PARAMS_YAML) "$(cat ${PROJECT_DIR}/harbor/registry/github.json)")
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data "${GITHUB_REGISTRY}"
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @${PROJECT_DIR}/harbor/replication/tailscale.json

--- a/harbor/project/network.json
+++ b/harbor/project/network.json
@@ -1,0 +1,11 @@
+{
+  "project_name": "network",
+  "metadata": {
+    "auto_scan": "true",
+    "enable_content_trust": "false",
+    "prevent_vul": "true",
+    "public": "true",
+    "reuse_sys_cve_whitelist": "true",
+    "severity": "critical"
+  }
+}

--- a/harbor/registry/github.json
+++ b/harbor/registry/github.json
@@ -1,0 +1,17 @@
+{
+    "id": 3,
+    "name": "github",
+    "description": "",
+    "type": "docker-registry",
+    "url": "https://ghcr.io",
+    "token_service_url": "",
+    "credential": {
+      "type": "",
+      "access_key": $githubUser,
+      "access_secret": $githubToken
+    },
+    "insecure": false,
+    "status": "healthy",
+    "creation_time": "2020-08-14T17:21:11.034238Z",
+    "update_time": "2020-08-14T17:21:11.034241Z"
+  }

--- a/harbor/replication/tailscale.json
+++ b/harbor/replication/tailscale.json
@@ -1,0 +1,27 @@
+{
+  "name": "tailscale",
+  "description": "",
+  "creator": "admin",
+  "src_registry": {
+    "id": 3
+  },
+  "dest_registry": {
+    "id": 0
+  },
+  "dest_namespace": "network",
+  "filters": [
+      {
+          "type": "name",
+          "value": "tailscale/tailscale"
+      }
+  ],
+  "trigger": {
+    "type": "scheduled",
+    "trigger_settings": {
+      "cron": "0 */10 * * * *"
+    }
+  },
+  "deletion": false,
+  "override": true,
+  "enabled": true
+}

--- a/harbor/replication/tailscale.json
+++ b/harbor/replication/tailscale.json
@@ -13,12 +13,16 @@
       {
           "type": "name",
           "value": "tailscale/tailscale"
+      },
+      { 
+        "type": "tag",
+        "value": "latest"
       }
   ],
   "trigger": {
     "type": "scheduled",
     "trigger_settings": {
-      "cron": "0 */10 * * * *"
+      "cron": "0 20 10 */1,7,14,28 * *"
     }
   },
   "deletion": false,

--- a/secrets/params.yml.enc
+++ b/secrets/params.yml.enc
@@ -1,0 +1,23 @@
+-----BEGIN PGP MESSAGE-----
+Comment: https://keybase.io/download
+Version: Keybase Go 5.8.0 (darwin)
+
+wcFMA8VJ3yZyDr3eARAAmCwBqHtKz7olFp/h/N0i/kSo7ncgfVrnBNVtUh9f0mm0
+TCdni49av1Ww/kz3ByaKsPP9WCF+EWFa7wz8K/i47z+S3hGnkDqXbq9AHrmE/L2H
+KWDWlo1NIzeoJ/XiCTOwFH71CLdXcZfuIqEPbCK/t3PjURIL0QeolApCtXPfYFsO
+OHaQV00MwXsTdhX4HPyMA34z5vV/g2myjkjDgpgNaYuetyu8GriDDSDK8eU0pAP0
+NNsot6DVvLF9hgJChcBKlUXhcQEmbMsinar/zuoPYYQKRvhPqhaAhuWyZi4VyMMI
+Jb4IHXC0CxRbb7bpTiHkN4kg/eTTjWRGwavkLVhJN+dT/wt4hKmLkKP61UMW2T/N
+LPbUnRamEqtXaRDoDNno0aFh7gtBoBv8ob511o829O2BkWAfNH8yT26FALfCADwe
+t5l0BccJwiFx6Z39Zh7WmXRtnQvnZ3YdhqV3i4A4U3SIlzZmvbIxIYYK2rdemdXX
+n+SQ0sxmIgbrtt0CIH28FM+ZZCFPOBhRQQnpxAkWeaLCkvHUIgEWOGZAJBFp2usC
+DNEt4Q5lQm+EB1RwkqSfoNeHxT4zq7kH1hRuXjTLznifkvnCA/TfYmm9+SCZO/qQ
+LBFc5YggkwuhrjJcfPy31elcVN7rlCZrFHemkl4qhMox2n//iJ5vrKx5jmN0bpjS
+4AHkEYEBxETL2lN8WFe3uuykaeHV7eDJ4KLhv0PgxeKs7dG94Irn0z3CROWJRo1F
+ckRuiUx2QMhFDWVL2eaGGYnzzGnplbC7hdw8+iz+LCmExxwmNYn9KCRNQTmOpfVz
+r8Ug2fdmsjAPPvlD4tDyJUFiJyCNq7yZk9sabTIHU/zccWIMHsqKnqCXLMOcPmu0
+9h11n+qfa1gknwvYQkHMkEr9B74jlmbgjeWnTAbwAu3W5qbhtePQd604Lu1prHEr
+qUX1rSVzLQJBt+Ce4tZNQ2ngRuAV4E/ksAd1tjY/xxG2WvqgdwB86+JV4X7Z4U8Y
+AA==
+=S+8R
+-----END PGP MESSAGE-----

--- a/src/pipeline/create-imaage.yml
+++ b/src/pipeline/create-imaage.yml
@@ -1,0 +1,48 @@
+---
+resources:
+# The repo with our Dockerfile
+- name: tailscale-source
+  type: git
+  icon: github
+  source:
+    uri: ((git.repository))
+    branch: ((git.branch))
+    paths: 
+    - "docs/k8s/*"
+
+# Where we will push the image
+- name: tailscale-proxy-image
+  type: registry-image
+  icon: docker
+  source:
+    # You need to provide these variables when
+    # setting the pipeline
+    repository: ((registry.fqdn))/((image.repository))
+    username: ((registry.robot))
+    password: ((registry.token))
+
+jobs:
+- name: create-image
+  plan:
+  - get: tailscale-source
+  - task: build-image
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          # Check out the README for oci-build-task at
+          # https://github.com/concourse/oci-build-task
+          repository: concourse/oci-build-task
+      inputs:
+      - name: tailscale-source
+      outputs:
+      - name: image
+      params:
+        CONTEXT: tailscale-source/docs/k8s
+      run:
+        path: build
+  - put: tailscale-proxy-image
+    params:
+      image: image/image.tar

--- a/src/pipeline/params.yml
+++ b/src/pipeline/params.yml
@@ -1,0 +1,8 @@
+---
+git:
+  repository: https://github.com/tailscale/tailscale.git
+  branch: release-branch/1.18
+
+image:
+  repository: network/tailscale-proxy
+


### PR DESCRIPTION
TL;DR
-----

Uses the tailscale source code to build an image for the proxy

Details
-------

Implements a simple pipeline that creates an image for the proxy
from the example in the Tailscale source code. The pipeline uses
the `Dockerfile` provided in the source repo to build the image,
the pushes it to the local registry.

Also implements a script `setup-harbor` the prepares the local
registry by configuring the `network` project that the new image
gets pushed to. There's also are replication setup so that the new
image can be build based on a local version of the base image that
Tailscale provides on GitHub.

The replication is currently unused since we leverage the existing
source code to build the image.
