### PR TITLE
Uses `network` concourse team

### DIFF
--- a/bin/populate-vault
+++ b/bin/populate-vault
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-put-secret --team platform-team \
+put-secret --team network \
   --var registry fqdn="$(yq e .registry.fqdn ${PARAMS_YAML})" \
                  robot="$(yq e .registry.robot ${PARAMS_YAML})" \
                  token="$(yq e .registry.token ${PARAMS_YAML})"
 
-put-secret --team platform-team \
+put-secret --team network \
   --var kubeconfig value="$(cat ${SECRETS_DIR}/kubeconfig)"
 
-put-secret --team platform-team --pipeline "$(basename ${PROJECT_DIR})" \
+put-secret --team network --pipeline "$(basename ${PROJECT_DIR})" \
   --var auth-key value="$(yq e .tailscale.auth-key ${PARAMS_YAML})" 
 


### PR DESCRIPTION
TL;DR
-----

Sets secrets for the `network`  team

Details
-------
Updates `populate-vault` to but secrets under the `network` concourse
team instead of the `platform-team` team.
